### PR TITLE
use underscore topics notation

### DIFF
--- a/lib/scompler/kafka/topic_mapper.rb
+++ b/lib/scompler/kafka/topic_mapper.rb
@@ -6,17 +6,17 @@ module Scompler
       # @param topic [String, Symbol] The topic
       # @return [String, Symbol] topic as on input
       # @example
-      #   incoming('uat.scompler.topic.created') #=> 'topic_created'
+      #   incoming('uat_scompler_topic_created') #=> 'topic_created'
       def incoming(topic)
-        topic.to_s.gsub(prefix, '').gsub('.', '_')
+        topic.to_s.gsub(prefix, '')
       end
 
       # @param topic [String, Symbol] The topic
-      # @return [String, Symbol] topic as on input
+      # @return [String, Symbol] topic as on input with prefix
       # @example
-      #   outgoing('topic_created') #=> 'topic.created'
+      #   outgoing('topic_created') #=> 'uat_scompler_topic_created'
       def outgoing(topic)
-        [prefix, topic.to_s.gsub('_', '.')].join
+        [prefix, topic.to_s].join
       end
 
       def schema_name_from_topic(topic)
@@ -27,7 +27,7 @@ module Scompler
         @prefix ||= [
           ENV['CLUSTER_NAME'],
           Scompler::Kafka.config.scope.to_s
-        ].reject(&:blank?).join('.').concat('.')
+        ].reject(&:blank?).join('_').concat('_')
       end
     end
   end

--- a/lib/scompler/kafka/version.rb
+++ b/lib/scompler/kafka/version.rb
@@ -2,6 +2,6 @@
 
 module Scompler
   module Kafka
-    VERSION = '0.1.6'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Task: [[TD] Bump Sidekiq from 5.2.10 to 6.5.7](https://app.asana.com/0/852357568736115/1203234815474438)

Due to upgrading karafka https://karafka.io/docs/Upgrades-2.0/#topic-mappers-are-no-longer-supported. In the previous version used dot notation for Kafka topics, e.g. `uat.scompler.article.created`. Now it's not possible to use custom topics and they should be generated as `uat_scompler_article_created`.